### PR TITLE
#30 Replace H2 database with Postgres for production

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: target/universal/stage/bin/socobo-server -Dhttp.port=$PORT
+web: target/universal/stage/bin/socobo-server -Dhttp.port=$PORT -Dconfig.resource=production.conf -DapplyEvolutions.default=true

--- a/app/Global.java
+++ b/app/Global.java
@@ -1,3 +1,5 @@
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -73,7 +75,8 @@ public static class SpringDataJpaConfiguration {
 
     @Bean
     public EntityManagerFactory entityManagerFactory() {
-        return Persistence.createEntityManagerFactory(DEFAULT_PERSISTENCE_UNIT);
+        Config conf = ConfigFactory.load();
+        return Persistence.createEntityManagerFactory(conf.getString("jpa.default"));
     }
 
     @Bean

--- a/app/models/user/User.java
+++ b/app/models/user/User.java
@@ -11,6 +11,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 
 @Entity
+@Table(name="socobo_user")
 public class User {
 
     public String name;

--- a/conf/META-INF/persistence.xml
+++ b/conf/META-INF/persistence.xml
@@ -7,6 +7,14 @@
         <provider>org.hibernate.ejb.HibernatePersistence</provider>
         <non-jta-data-source>DefaultDS</non-jta-data-source>
         <properties>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="update"/>
+        </properties>
+    </persistence-unit>
+    <persistence-unit name="localPersistenceUnit">
+        <provider>org.hibernate.ejb.HibernatePersistence</provider>
+        <non-jta-data-source>LocalDS</non-jta-data-source>
+        <properties>
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
             <property name="hibernate.hbm2ddl.auto" value="update"/>
             <property name="hibernate.show_sql" value="true"></property>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -33,22 +33,22 @@ application.langs="en"
 # You can declare as many datasources as you want.
 # By convention, the default datasource is named `default`
 #
-db.default.driver=org.h2.Driver
-db.default.url="jdbc:h2:mem:play"
-db.default.user=sa
-db.default.password=""
-//
-//db.default.driver=com.mysql.jdbc.Driver
-//db.default.url="jdbc:mysql://dbserv.ba-leipzig.de/cs13tf1"
-//db.default.user=cs13tf1
-//db.default.password=${?MYSQL_PW}
+//db.default.driver=org.h2.Driver
+//db.default.url="jdbc:h2:mem:play"
+//db.default.user=sa
+//db.default.password=""
+
+db.default.driver=org.postgresql.Driver
+db.default.url="jdbc:postgresql://localhost:5432/socobo"
+db.default.user=postgres
+db.default.password="password"
 
 # db.default.logStatements=true
 logger.com.jolbox=DEBUG
 #
 # You can expose this datasource via JNDI if needed (Useful for JPA)
-db.default.jndiName=DefaultDS
-jpa.default=defaultPersistenceUnit
+db.default.jndiName=LocalDS
+jpa.default=localPersistenceUnit
 
 # Evolutions
 # ~~~~~

--- a/conf/production.conf
+++ b/conf/production.conf
@@ -1,0 +1,9 @@
+include "application.conf"
+
+db.default.driver=org.postgresql.Driver
+db.default.url=${DATABASE_URL}
+db.default.user=${PG_BLACK_USER}
+db.default.password=${PG_BLACK_PW}
+
+db.default.jndiName=DefaultDS
+jpa.default=defaultPersistenceUnit

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,7 +17,8 @@ object ApplicationBuild extends Build {
     "org.springframework" % "spring-expression" % "3.2.2.RELEASE",
     "org.hibernate" % "hibernate-entitymanager" % "3.6.10.Final",
     "org.mockito" % "mockito-core" % "1.9.5" % "test",
-    "org.webjars" % "bootstrap" % "3.0.0"
+    "org.webjars" % "bootstrap" % "3.0.0",
+    "postgresql" % "postgresql" % "9.1-901.jdbc4"
   )
   val main = Project(appName, file(".")).enablePlugins(play.PlayJava).settings(
     playVersion := appVersion,


### PR DESCRIPTION
Add separate production configuration that holds the Heroku database information (via env variables)
Add Postgres JDBC driver dependency
Add persistence-unit for Postgres
Change Procfile to use DB evolutions and the production configuration