### PR TITLE
#30 Replace H2 database with Postgres for production

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -33,15 +33,10 @@ application.langs="en"
 # You can declare as many datasources as you want.
 # By convention, the default datasource is named `default`
 #
-//db.default.driver=org.h2.Driver
-//db.default.url="jdbc:h2:mem:play"
-//db.default.user=sa
-//db.default.password=""
-
-db.default.driver=org.postgresql.Driver
-db.default.url="jdbc:postgresql://localhost:5432/socobo"
-db.default.user=postgres
-db.default.password="password"
+db.default.driver=org.h2.Driver
+db.default.url="jdbc:h2:mem:play"
+db.default.user=sa
+db.default.password=""
 
 # db.default.logStatements=true
 logger.com.jolbox=DEBUG


### PR DESCRIPTION
Remove redundant local Postgres configuration from application.conf as the default db